### PR TITLE
feat: add v1 API prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To run `simple-sync` using Docker Compose:
 
 4. Verify the service is running:
    ```bash
-   curl http://localhost:8080/health
+    curl http://localhost:8080/api/v1/health
    ```
    You should see a JSON response with status "healthy".
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,11 +4,11 @@ This document describes the API endpoints for the `simple-sync` system.
 
 ## Authentication
 
-All endpoints (except `/auth/token`) require authentication. The authentication mechanism involves a JSON Web Token (JWT) passed in the `Authorization` header.
+All endpoints (except `/api/v1/auth/token`) require authentication. The authentication mechanism involves a JSON Web Token (JWT) passed in the `Authorization` header.
 
 ## Events
 
-### `GET /events`
+### `GET /api/v1/events`
 
 *   **Purpose:** Retrieve the authoritative event history.
 *   **Method:** GET
@@ -20,7 +20,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
 *   **Example Request:**
 
     ```
-    GET /events?fromTimestamp=1678886400
+    GET /api/v1/events?fromTimestamp=1678886400
     Authorization: Bearer <JWT>
     ```
 
@@ -47,7 +47,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
     ]
     ```
 
-### `POST /events`
+### `POST /api/v1/events`
 
 *   **Purpose:** Push the client's diff history to the server.
 *   **Method:** POST
@@ -59,7 +59,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
 *   **Example Request:**
 
     ```
-    POST /events
+    POST /api/v1/events
     Authorization: Bearer <JWT>
     Content-Type: application/json
 
@@ -108,7 +108,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
 
 ## ACL
 
-### `GET /acl`
+### `GET /api/v1/acl`
 
 *   **Purpose:** Retrieve the current ACL.
 *   **Method:** GET
@@ -119,7 +119,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
 *   **Example Request:**
 
     ```
-    GET /acl
+    GET /api/v1/acl
     Authorization: Bearer <JWT>
     ```
 
@@ -150,7 +150,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
     }
     ```
 
-### `PUT /acl`
+### `PUT /api/v1/acl`
 
 *   **Purpose:** Update the ACL.
 *   **Method:** PUT
@@ -163,7 +163,7 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
 *   **Example Request:**
 
     ```
-    PUT /acl
+    PUT /api/v1/acl
     Authorization: Bearer <JWT>
     Content-Type: application/json
 
@@ -199,11 +199,11 @@ All endpoints (except `/auth/token`) require authentication. The authentication 
 
 ### ACL Access Control
 
-Access to the `/acl` endpoint is restricted to administrators. Administrators are defined via a list of usernames in the server's configuration (TOML) file. See [ACL Documentation](docs/acl.md) for more details on the ACL structure and syntax.
+Access to the `/api/v1/acl` endpoint is restricted to administrators. Administrators are defined via a list of usernames in the server's configuration (TOML) file. See [ACL Documentation](docs/acl.md) for more details on the ACL structure and syntax.
 
 ## Health Check
 
-### `GET /health`
+### `GET /api/v1/health`
 
 *   **Purpose:** Check the health status of the service.
 *   **Method:** GET
@@ -213,7 +213,7 @@ Access to the `/acl` endpoint is restricted to administrators. Administrators ar
 *   **Example Request:**
 
     ```
-    GET /health
+    GET /api/v1/health
     ```
 
 *   **Example Response:**
@@ -229,7 +229,7 @@ Access to the `/acl` endpoint is restricted to administrators. Administrators ar
 
 ## Authentication
 
-### `POST /auth/token`
+### `POST /api/v1/auth/token`
 
 *   **Purpose:** Obtain an authentication token.
 *   **Method:** POST
@@ -241,7 +241,7 @@ Access to the `/acl` endpoint is restricted to administrators. Administrators ar
 *   **Example Request:**
 
     ```
-    POST /auth/token
+    POST /api/v1/auth/token
     Content-Type: application/json
 
     {
@@ -262,7 +262,7 @@ Access to the `/acl` endpoint is restricted to administrators. Administrators ar
 
 The following endpoints are part of the Admin API and are used for managing users. These endpoints use the same authentication mechanism as the regular user API. Access to these endpoints is restricted to administrators defined via a list of usernames in the server's configuration (TOML) file.
 
-### `POST /admin/users`
+### `POST /api/v1/admin/users`
 
 *   **Purpose:** Create a new user.
 *   **Method:** POST
@@ -275,7 +275,7 @@ The following endpoints are part of the Admin API and are used for managing user
 *   **Example Request:**
 
     ```
-    POST /admin/users
+    POST /api/v1/admin/users
     Authorization: Bearer <JWT>
     Content-Type: application/json
 
@@ -295,7 +295,7 @@ The following endpoints are part of the Admin API and are used for managing user
     }
     ```
 
-### `PUT /admin/users/{uuid}`
+### `PUT /api/v1/admin/users/{uuid}`
 
 *   **Purpose:** Update a user's username and/or password.
 *   **Method:** PUT
@@ -310,7 +310,7 @@ The following endpoints are part of the Admin API and are used for managing user
 *   **Example Request:**
 
     ```
-    PUT /admin/users/newuser123
+    PUT /api/v1/admin/users/newuser123
     Authorization: Bearer <JWT>
     Content-Type: application/json
 

--- a/src/main.go
+++ b/src/main.go
@@ -43,16 +43,18 @@ func main() {
 	router.SetTrustedProxies([]string{})
 
 	// Register routes
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 	auth.POST("/events", h.PostEvents)
 
 	// Auth routes (no middleware)
-	router.POST("/auth/token", h.PostAuthToken)
+	v1.POST("/auth/token", h.PostAuthToken)
 
 	// Health check route (no middleware)
-	router.GET("/health", h.GetHealth)
+	v1.GET("/health", h.GetHealth)
 
 	// Use port from environment configuration
 	port := envConfig.Port

--- a/tests/contract/auth_token_post_test.go
+++ b/tests/contract/auth_token_post_test.go
@@ -22,7 +22,8 @@ func TestPostAuthToken(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
+	v1 := router.Group("/api/v1")
+	v1.POST("/auth/token", h.PostAuthToken)
 
 	// Test data from contract
 	authRequest := map[string]string{
@@ -32,7 +33,7 @@ func TestPostAuthToken(t *testing.T) {
 	requestBody, _ := json.Marshal(authRequest)
 
 	// Create test request
-	req, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(requestBody))
+	req, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(requestBody))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -60,7 +61,8 @@ func TestPostAuthTokenInvalidRequest(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
+	v1 := router.Group("/api/v1")
+	v1.POST("/auth/token", h.PostAuthToken)
 
 	// Invalid request - missing password
 	invalidRequest := map[string]string{
@@ -68,7 +70,7 @@ func TestPostAuthTokenInvalidRequest(t *testing.T) {
 	}
 	requestBody, _ := json.Marshal(invalidRequest)
 
-	req, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(requestBody))
+	req, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(requestBody))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -87,7 +89,8 @@ func TestPostAuthTokenInvalidCredentials(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
+	v1 := router.Group("/api/v1")
+	v1.POST("/auth/token", h.PostAuthToken)
 
 	// Invalid credentials
 	authRequest := map[string]string{
@@ -96,7 +99,7 @@ func TestPostAuthTokenInvalidCredentials(t *testing.T) {
 	}
 	requestBody, _ := json.Marshal(authRequest)
 
-	req, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(requestBody))
+	req, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(requestBody))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/tests/contract/events_get_protected_test.go
+++ b/tests/contract/events_get_protected_test.go
@@ -22,12 +22,13 @@ func TestGetEventsProtected(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth middleware
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 
 	// Test without Authorization header - should fail with 401
-	req, _ := http.NewRequest("GET", "/events", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -52,7 +53,8 @@ func TestGetEventsWithValidToken(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth middleware
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 
@@ -61,7 +63,7 @@ func TestGetEventsWithValidToken(t *testing.T) {
 	token, _ := h.AuthService().GenerateToken(user)
 
 	// Test with valid Authorization header
-	req, _ := http.NewRequest("GET", "/events", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 
@@ -84,12 +86,13 @@ func TestGetEventsWithInvalidToken(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth middleware
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 
 	// Test with invalid Authorization header
-	req, _ := http.NewRequest("GET", "/events", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	req.Header.Set("Authorization", "Bearer invalid-token")
 	w := httptest.NewRecorder()
 

--- a/tests/contract/events_post_protected_test.go
+++ b/tests/contract/events_post_protected_test.go
@@ -23,7 +23,8 @@ func TestPostEventsProtected(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth middleware
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.POST("/events", h.PostEvents)
 
@@ -38,7 +39,7 @@ func TestPostEventsProtected(t *testing.T) {
 	}]`
 
 	// Test without Authorization header - should fail with 401
-	req, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	req, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -64,7 +65,8 @@ func TestPostEventsWithValidToken(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.POST("/events", h.PostEvents)
 
@@ -83,7 +85,7 @@ func TestPostEventsWithValidToken(t *testing.T) {
 	}]`
 
 	// Test with valid Authorization header
-	req, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	req, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
@@ -107,7 +109,8 @@ func TestPostEventsWithInvalidToken(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.POST("/events", h.PostEvents)
 
@@ -122,7 +125,7 @@ func TestPostEventsWithInvalidToken(t *testing.T) {
 	}]`
 
 	// Test with invalid Authorization header
-	req, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	req, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer invalid-token")
 	w := httptest.NewRecorder()

--- a/tests/contract/get_events_test.go
+++ b/tests/contract/get_events_test.go
@@ -21,7 +21,8 @@ func TestGetEvents(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 
@@ -30,7 +31,7 @@ func TestGetEvents(t *testing.T) {
 	token, _ := h.AuthService().GenerateToken(user)
 
 	// Create test request
-	req, _ := http.NewRequest("GET", "/events", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 

--- a/tests/contract/get_events_timestamp_test.go
+++ b/tests/contract/get_events_timestamp_test.go
@@ -22,7 +22,8 @@ func TestGetEventsWithTimestamp(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 
@@ -31,7 +32,7 @@ func TestGetEventsWithTimestamp(t *testing.T) {
 	token, _ := h.AuthService().GenerateToken(user)
 
 	// Create test request with timestamp query
-	req, _ := http.NewRequest("GET", "/events?fromTimestamp=1640995200", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/events?fromTimestamp=1640995200", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 
@@ -56,7 +57,8 @@ func TestGetEventsWithTimestampFiltering(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 	auth.POST("/events", h.PostEvents)
@@ -68,7 +70,7 @@ func TestGetEventsWithTimestampFiltering(t *testing.T) {
 	// Post some events with different timestamps
 	eventJSON := `[{"uuid":"1","timestamp":100,"userUuid":"u1","itemUuid":"i1","action":"a","payload":"p"}, {"uuid":"2","timestamp":200,"userUuid":"u2","itemUuid":"i2","action":"b","payload":"q"}, {"uuid":"3","timestamp":300,"userUuid":"u3","itemUuid":"i3","action":"c","payload":"r"}]`
 
-	req, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	req, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
@@ -76,7 +78,7 @@ func TestGetEventsWithTimestampFiltering(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Now GET with fromTimestamp=150
-	req2, _ := http.NewRequest("GET", "/events?fromTimestamp=150", nil)
+	req2, _ := http.NewRequest("GET", "/api/v1/events?fromTimestamp=150", nil)
 	req2.Header.Set("Authorization", "Bearer "+token)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, req2)

--- a/tests/contract/health_get_test.go
+++ b/tests/contract/health_get_test.go
@@ -21,10 +21,11 @@ func TestGetHealth(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.GET("/health", h.GetHealth)
+	v1 := router.Group("/api/v1")
+	v1.GET("/health", h.GetHealth)
 
-	// Test GET /health endpoint
-	req, _ := http.NewRequest("GET", "/health", nil)
+	// Test GET /api/v1/health endpoint
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)

--- a/tests/contract/post_events_test.go
+++ b/tests/contract/post_events_test.go
@@ -26,7 +26,8 @@ func TestPostEvents(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth middleware
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.POST("/events", h.PostEvents)
 
@@ -45,7 +46,7 @@ func TestPostEvents(t *testing.T) {
 	token, _ := h.AuthService().GenerateToken(user)
 
 	// Create test request
-	req, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	req, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
@@ -78,7 +79,8 @@ func TestConcurrentPostEvents(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes with auth
-	auth := router.Group("/")
+	v1 := router.Group("/api/v1")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.POST("/events", h.PostEvents)
 	auth.GET("/events", h.GetEvents)
@@ -100,7 +102,7 @@ func TestConcurrentPostEvents(t *testing.T) {
 			for j := 0; j < eventsPerGoroutine; j++ {
 				uuid := fmt.Sprintf("%d-%d", id, j)
 				event := fmt.Sprintf(`[{"uuid":"%s","timestamp":%d,"userUuid":"u","itemUuid":"i","action":"a","payload":"p"}]`, uuid, id*100+j+1)
-				req, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(event))
+				req, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(event))
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("Authorization", "Bearer "+token) // Add token
 				w := httptest.NewRecorder()
@@ -116,7 +118,7 @@ func TestConcurrentPostEvents(t *testing.T) {
 	wg.Wait()
 
 	// Check total events
-	req, _ := http.NewRequest("GET", "/events", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)

--- a/tests/integration/auth_invalid_test.go
+++ b/tests/integration/auth_invalid_test.go
@@ -22,8 +22,9 @@ func TestInvalidCredentialsHandling(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
-	router.GET("/events", h.GetEvents)
+	v1 := router.Group("/api/v1")
+	v1.POST("/auth/token", h.PostAuthToken)
+	v1.GET("/events", h.GetEvents)
 
 	// Test 1: Invalid username/password
 	authRequest := map[string]string{
@@ -32,7 +33,7 @@ func TestInvalidCredentialsHandling(t *testing.T) {
 	}
 	authBody, _ := json.Marshal(authRequest)
 
-	authReq, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(authBody))
+	authReq, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
 	authW := httptest.NewRecorder()
 
@@ -53,7 +54,7 @@ func TestInvalidCredentialsHandling(t *testing.T) {
 	}
 	malformedBody, _ := json.Marshal(malformedRequest)
 
-	malformedReq, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(malformedBody))
+	malformedReq, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(malformedBody))
 	malformedReq.Header.Set("Content-Type", "application/json")
 	malformedW := httptest.NewRecorder()
 
@@ -63,7 +64,7 @@ func TestInvalidCredentialsHandling(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, malformedW.Code)
 
 	// Test 3: Access with invalid token
-	getReq, _ := http.NewRequest("GET", "/events", nil)
+	getReq, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	getReq.Header.Set("Authorization", "Bearer invalid-token")
 	getW := httptest.NewRecorder()
 
@@ -74,7 +75,7 @@ func TestInvalidCredentialsHandling(t *testing.T) {
 
 	// Test 4: Access with expired token (simulate)
 	// Note: This would require implementing token expiration
-	getExpiredReq, _ := http.NewRequest("GET", "/events", nil)
+	getExpiredReq, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	getExpiredReq.Header.Set("Authorization", "Bearer expired-jwt-token")
 	getExpiredW := httptest.NewRecorder()
 

--- a/tests/integration/auth_success_test.go
+++ b/tests/integration/auth_success_test.go
@@ -23,10 +23,11 @@ func TestSuccessfulAuthenticationFlow(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
+	v1 := router.Group("/api/v1")
+	v1.POST("/auth/token", h.PostAuthToken)
 
 	// Protected routes with auth middleware
-	auth := router.Group("/")
+	auth := v1.Group("/")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 	auth.POST("/events", h.PostEvents)
@@ -38,7 +39,7 @@ func TestSuccessfulAuthenticationFlow(t *testing.T) {
 	}
 	authBody, _ := json.Marshal(authRequest)
 
-	authReq, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(authBody))
+	authReq, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
 	authW := httptest.NewRecorder()
 
@@ -54,7 +55,7 @@ func TestSuccessfulAuthenticationFlow(t *testing.T) {
 	assert.NotEmpty(t, token)
 
 	// Step 2: Use token to access protected GET /events
-	getReq, _ := http.NewRequest("GET", "/events", nil)
+	getReq, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	getReq.Header.Set("Authorization", "Bearer "+token)
 	getW := httptest.NewRecorder()
 
@@ -73,7 +74,7 @@ func TestSuccessfulAuthenticationFlow(t *testing.T) {
 		"payload": "{}"
 	}]`
 
-	postReq, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	postReq, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	postReq.Header.Set("Content-Type", "application/json")
 	postReq.Header.Set("Authorization", "Bearer "+token)
 	postW := httptest.NewRecorder()

--- a/tests/integration/protected_access_test.go
+++ b/tests/integration/protected_access_test.go
@@ -23,16 +23,16 @@ func TestProtectedEndpointAccess(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
+	router.POST("/api/v1/auth/token", h.PostAuthToken)
 
 	// Protected routes with auth middleware
-	auth := router.Group("/")
+	auth := router.Group("/api/v1")
 	auth.Use(middleware.AuthMiddleware(h.AuthService()))
 	auth.GET("/events", h.GetEvents)
 	auth.POST("/events", h.PostEvents)
 
 	// Test 1: Access GET /events without token - should fail
-	getReq, _ := http.NewRequest("GET", "/events", nil)
+	getReq, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	getW := httptest.NewRecorder()
 
 	router.ServeHTTP(getW, getReq)
@@ -50,7 +50,7 @@ func TestProtectedEndpointAccess(t *testing.T) {
 		"payload": "{}"
 	}]`
 
-	postReq, _ := http.NewRequest("POST", "/events", bytes.NewBufferString(eventJSON))
+	postReq, _ := http.NewRequest("POST", "/api/v1/events", bytes.NewBufferString(eventJSON))
 	postReq.Header.Set("Content-Type", "application/json")
 	postW := httptest.NewRecorder()
 
@@ -66,7 +66,7 @@ func TestProtectedEndpointAccess(t *testing.T) {
 	}
 	authBody, _ := json.Marshal(authRequest)
 
-	authReq, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(authBody))
+	authReq, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
 	authW := httptest.NewRecorder()
 
@@ -80,7 +80,7 @@ func TestProtectedEndpointAccess(t *testing.T) {
 	token := authResponse["token"]
 
 	// Now access with token
-	authGetReq, _ := http.NewRequest("GET", "/events", nil)
+	authGetReq, _ := http.NewRequest("GET", "/api/v1/events", nil)
 	authGetReq.Header.Set("Authorization", "Bearer "+token)
 	authGetW := httptest.NewRecorder()
 

--- a/tests/performance/auth_performance_test.go
+++ b/tests/performance/auth_performance_test.go
@@ -24,7 +24,8 @@ func TestAuthEndpointPerformance(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register routes
-	router.POST("/auth/token", h.PostAuthToken)
+	v1 := router.Group("/api/v1")
+	v1.POST("/auth/token", h.PostAuthToken)
 
 	// Test auth endpoint performance
 	authRequest := map[string]string{
@@ -34,7 +35,7 @@ func TestAuthEndpointPerformance(t *testing.T) {
 	authBody, _ := json.Marshal(authRequest)
 
 	start := time.Now()
-	req, _ := http.NewRequest("POST", "/auth/token", bytes.NewBuffer(authBody))
+	req, _ := http.NewRequest("POST", "/api/v1/auth/token", bytes.NewBuffer(authBody))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/tests/performance/health_performance_test.go
+++ b/tests/performance/health_performance_test.go
@@ -21,11 +21,12 @@ func TestHealthEndpointPerformance(t *testing.T) {
 	h := handlers.NewTestHandlers()
 
 	// Register health route
-	router.GET("/health", h.GetHealth)
+	v1 := router.Group("/api/v1")
+	v1.GET("/health", h.GetHealth)
 
 	// Test health endpoint performance
 	start := time.Now()
-	req, _ := http.NewRequest("GET", "/health", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)


### PR DESCRIPTION
Update all API endpoints to start with /api/v1/ for future versioning. Update main.go, tests, docs, and README.