### PR TITLE
docs: update API spec to use v7 UUID

### DIFF
--- a/docs/src/content/docs/api/v1.md
+++ b/docs/src/content/docs/api/v1.md
@@ -37,7 +37,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
     ```json
     [
         {
-            "uuid": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+            "uuid": "0186e56d-7000-7000-8040-940f030080ad",
             "timestamp": 1678886400,
             "user": "user.123",
             "item": "task.456",
@@ -45,7 +45,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
             "payload": "{}"
         },
         {
-            "uuid": "b2c3d4e5-f6a7-8901-2345-67890abcdef0",
+            "uuid": "0186e56d-73e8-7000-8012-51aacd3dbf8e",
             "timestamp": 1678886401,
             "user": "user.123",
             "item": "task.456",
@@ -74,7 +74,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
 
     [
         {
-            "uuid": "c3d4e5f6-a7b8-9012-3456-7890abcdef01",
+            "uuid": "0186e56d-77d0-7000-8003-c289bf62cf41",
             "timestamp": 1678886402,
             "user": "user.123",
             "item": "item.789",
@@ -89,7 +89,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
     ```json
     [
         {
-            "uuid": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+            "uuid": "0186e56d-7000-7000-8040-940f030080ad",
             "timestamp": 1678886400,
             "user": "user.123",
             "item": "item.456",
@@ -97,7 +97,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
             "payload": "{}"
         },
         {
-            "uuid": "b2c3d4e5-f6a7-8901-2345-67890abcdef0",
+            "uuid": "0186e56d-73e8-7000-8012-51aacd3dbf8e",
             "timestamp": 1678886401,
             "user": "user.123",
             "item": "item.456",
@@ -105,7 +105,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
             "payload": "{\"title\": \"New Title\"}"
         },
         {
-            "uuid": "c3d4e5f6-a7b8-9012-3456-7890abcdef01",
+            "uuid": "0186e56d-77d0-7000-8003-c289bf62cf41",
             "timestamp": 1678886402,
             "user": "user.123",
             "item": "item.789",
@@ -224,7 +224,7 @@ Setup tokens expire after 24 hours and can only be used once. Users can have mul
 
     ```json
     {
-        "keyUuid": "550e8400-e29b-41d4-a716-446655440000",
+        "keyUuid": "0199ab65-1a1e-7000-80f5-23a591c5106e",
         "apiKey": "sk_abcdefghijklmnopqrstuvwxyz1234567890",
         "user": "user.123",
         "description": "Desktop Client"


### PR DESCRIPTION

Resolves #33 

## Summary
- Replace v4 UUID examples with valid v7 UUIDs that correspond to the timestamps in the API documentation
- Update all event UUIDs and keyUuid examples to use proper v7 format with matching timestamps